### PR TITLE
[Mod] 게시글 줄바꿈 / 댓글 "수정됨" 로직 수정

### DIFF
--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -399,7 +399,7 @@ console.log('Hello World');
       ) : (
         <>
           <h1 className="text-3xl font-bold text-indigo-600 mt-6">{post.title}</h1>
-          <div className="mt-4 text-gray-700 text-lg leading-relaxed">
+          <div className="mt-4 text-gray-700 text-lg leading-relaxed whitespace-pre-line">
             <ReactMarkdown
               components={{
                 code: (props: any) => {
@@ -418,7 +418,8 @@ console.log('Hello World');
                       {children}
                     </code>
                   );
-                }
+                },
+                p: ({ children }) => <p className="whitespace-pre-line">{children}</p>
               }}
             >
               {post.content}

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -170,17 +170,21 @@ export default function PostDetail() {
         },
         body: JSON.stringify({
           postId: Number(postId),
-          content: editContent, // ❌ userId 제거
+          content: editContent,
         }),
       });
 
       if (!response.ok) throw new Error("댓글을 수정할 수 없습니다.");
 
       const updatedComments = comments.map((comment) =>
-        comment.id === commentId ? { ...comment, content: editContent } : comment
+        comment.id === commentId ? { 
+          ...comment, 
+          content: editContent,
+          updatedAt: new Date().toISOString()
+        } : comment
       );
       setComments(updatedComments);
-      setEditingComment(null); // ✅ 수정 모드 종료
+      setEditingComment(null);
     } catch (error) {
       console.error("댓글 수정 오류:", error);
     }
@@ -261,6 +265,7 @@ export default function PostDetail() {
         ...aiComment,
         userNickname: "TemuFlow GPT",
         userProfileImageUrl: "/TemuFlow-GPT.png",
+        updatedAt: "-999999999-01-01T00:00:00"
       };
       setComments([...comments, commentWithUserInfo]);
     } catch (error) {


### PR DESCRIPTION
## 수정한 코드
- 엔터키를 이용해 줄바꿈을 고려하여 게시글을 작성하였는데 실제 작성된 게시글을 보면 줄바꿈이 되지 않는 오류가 있어,
게시글 조회했을 때도 줄바꿈이 보이도록 코드 수정하였음
- 현재 댓글 수정 시에도 댓글이 "수정됨"이라고 표시되지 않고, 최초 댓글 작성 일자와 시간이 출력됨.
댓글 수정 시 <수정됨. [수정 일자, 시간]>의 형식으로 출력되게 코드 수정하였음

## 확인해야할 사항
- Temuflow-GPT가 생성한 댓글이 "수정됨"으로 표시되는 오류가 있었으나 이는 백엔드의 문제로 판단돼 백엔드에서 해결해야함(제가 바로 할 예정입니다)

Closed #32 #33 #34 